### PR TITLE
Add JsonSerializerSettings properties in serializer asset

### DIFF
--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertNamesAssetEditor.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertNamesAssetEditor.cs
@@ -11,6 +11,7 @@ namespace UGF.Serialize.JsonNet.Editor
         private SerializedProperty m_propertyScript;
         private SerializedProperty m_propertyReadable;
         private SerializedProperty m_propertyIndent;
+        private SerializedProperty m_propertySettings;
         private ReorderableListDrawer m_listSerializeNames;
         private ReorderableListDrawer m_listDeserializeNames;
 
@@ -19,6 +20,7 @@ namespace UGF.Serialize.JsonNet.Editor
             m_propertyScript = serializedObject.FindProperty("m_Script");
             m_propertyReadable = serializedObject.FindProperty("m_readable");
             m_propertyIndent = serializedObject.FindProperty("m_indent");
+            m_propertySettings = serializedObject.FindProperty("m_settings");
             m_listSerializeNames = new SerializerJsonNetConvertNamesListDrawer(serializedObject.FindProperty("m_serializeNames"));
             m_listDeserializeNames = new SerializerJsonNetConvertNamesListDrawer(serializedObject.FindProperty("m_deserializeNames"));
 
@@ -49,6 +51,7 @@ namespace UGF.Serialize.JsonNet.Editor
 
             EditorGUILayout.PropertyField(m_propertyReadable);
             EditorGUILayout.PropertyField(m_propertyIndent);
+            EditorGUILayout.PropertyField(m_propertySettings);
 
             m_listSerializeNames.DrawGUILayout();
             m_listDeserializeNames.DrawGUILayout();

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetAsset.cs
@@ -1,4 +1,6 @@
-﻿using UGF.Serialize.Runtime;
+﻿using Newtonsoft.Json;
+using UGF.JsonNet.Runtime;
+using UGF.Serialize.Runtime;
 using UnityEngine;
 
 namespace UGF.Serialize.JsonNet.Runtime
@@ -8,13 +10,49 @@ namespace UGF.Serialize.JsonNet.Runtime
     {
         [SerializeField] private bool m_readable;
         [SerializeField] private int m_indent = 2;
+        [SerializeField] private SerializerJsonNetSettings m_settings = new SerializerJsonNetSettings();
 
         public bool Readable { get { return m_readable; } set { m_readable = value; } }
         public int Indent { get { return m_indent; } set { m_indent = value; } }
+        public SerializerJsonNetSettings Settings { get { return m_settings; } }
 
         protected override ISerializer<string> OnBuildTyped()
         {
-            return new SerializerJsonNet(m_readable, m_indent);
+            JsonSerializerSettings settings = OnCreateSettings();
+
+            return new SerializerJsonNet(settings, m_readable, m_indent);
+        }
+
+        protected virtual JsonSerializerSettings OnCreateSettings()
+        {
+            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
+
+            settings.ReferenceLoopHandling = m_settings.ReferenceLoopHandling;
+            settings.MissingMemberHandling = m_settings.MissingMemberHandling;
+            settings.ObjectCreationHandling = m_settings.ObjectCreationHandling;
+            settings.NullValueHandling = m_settings.NullValueHandling;
+            settings.DefaultValueHandling = m_settings.DefaultValueHandling;
+            settings.PreserveReferencesHandling = m_settings.PreserveReferencesHandling;
+            settings.TypeNameHandling = m_settings.TypeNameHandling;
+            settings.MetadataPropertyHandling = m_settings.MetadataPropertyHandling;
+            settings.TypeNameAssemblyFormatHandling = m_settings.TypeNameAssemblyFormatHandling;
+            settings.ConstructorHandling = m_settings.ConstructorHandling;
+            settings.Formatting = m_settings.Formatting;
+            settings.DateFormatHandling = m_settings.DateFormatHandling;
+            settings.DateTimeZoneHandling = m_settings.DateTimeZoneHandling;
+            settings.DateParseHandling = m_settings.DateParseHandling;
+            settings.FloatFormatHandling = m_settings.FloatFormatHandling;
+            settings.FloatParseHandling = m_settings.FloatParseHandling;
+            settings.StringEscapeHandling = m_settings.StringEscapeHandling;
+            settings.DateFormatString = m_settings.DateFormatString;
+            settings.CheckAdditionalContent = m_settings.CheckAdditionalContent;
+
+            if (m_settings.MaxDepth > 0)
+            {
+                settings.MaxDepth = m_settings.MaxDepth;
+            }
+
+            return settings;
         }
     }
 }

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertNamesAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertNamesAsset.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using UGF.Serialize.Runtime;
 using UnityEngine;
 
@@ -31,7 +32,9 @@ namespace UGF.Serialize.JsonNet.Runtime
 
         protected override ISerializer<string> OnBuildTyped()
         {
-            var serializer = new SerializerJsonNetConvertNames(Readable, Indent);
+            JsonSerializerSettings settings = OnCreateSettings();
+
+            var serializer = new SerializerJsonNetConvertNames(settings, Readable, Indent);
 
             SetupNames(serializer);
 

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using UGF.EditorTools.Runtime.IMGUI.Types;
-using UGF.JsonNet.Runtime;
 using UGF.JsonNet.Runtime.Converters;
 using UGF.Serialize.Runtime;
 using UnityEngine;
@@ -40,7 +39,7 @@ namespace UGF.Serialize.JsonNet.Runtime
 
             SetupTypes(binder.Provider);
 
-            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
+            JsonSerializerSettings settings = OnCreateSettings();
 
             settings.SerializationBinder = binder;
 

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetSettings.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetSettings.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Newtonsoft.Json;
+using UnityEngine;
+
+namespace UGF.Serialize.JsonNet.Runtime
+{
+    [Serializable]
+    public class SerializerJsonNetSettings
+    {
+        [SerializeField] private ReferenceLoopHandling m_referenceLoopHandling = ReferenceLoopHandling.Ignore;
+        [SerializeField] private MissingMemberHandling m_missingMemberHandling = MissingMemberHandling.Ignore;
+        [SerializeField] private ObjectCreationHandling m_objectCreationHandling = ObjectCreationHandling.Auto;
+        [SerializeField] private NullValueHandling m_nullValueHandling = NullValueHandling.Ignore;
+        [SerializeField] private DefaultValueHandling m_defaultValueHandling = DefaultValueHandling.Include;
+        [SerializeField] private PreserveReferencesHandling m_preserveReferencesHandling = PreserveReferencesHandling.None;
+        [SerializeField] private TypeNameHandling m_typeNameHandling = TypeNameHandling.Auto;
+        [SerializeField] private MetadataPropertyHandling m_metadataPropertyHandling = MetadataPropertyHandling.Default;
+        [SerializeField] private TypeNameAssemblyFormatHandling m_typeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
+        [SerializeField] private ConstructorHandling m_constructorHandling = ConstructorHandling.Default;
+        [SerializeField] private Formatting m_formatting = Formatting.None;
+        [SerializeField] private DateFormatHandling m_dateFormatHandling = DateFormatHandling.IsoDateFormat;
+        [SerializeField] private DateTimeZoneHandling m_dateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
+        [SerializeField] private DateParseHandling m_dateParseHandling = DateParseHandling.DateTime;
+        [SerializeField] private FloatFormatHandling m_floatFormatHandling = FloatFormatHandling.String;
+        [SerializeField] private FloatParseHandling m_floatParseHandling = FloatParseHandling.Double;
+        [SerializeField] private StringEscapeHandling m_stringEscapeHandling = StringEscapeHandling.Default;
+        [SerializeField] private string m_dateFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
+        [SerializeField] private int m_maxDepth;
+        [SerializeField] private bool m_checkAdditionalContent;
+
+        public ReferenceLoopHandling ReferenceLoopHandling { get { return m_referenceLoopHandling; } set { m_referenceLoopHandling = value; } }
+        public MissingMemberHandling MissingMemberHandling { get { return m_missingMemberHandling; } set { m_missingMemberHandling = value; } }
+        public ObjectCreationHandling ObjectCreationHandling { get { return m_objectCreationHandling; } set { m_objectCreationHandling = value; } }
+        public NullValueHandling NullValueHandling { get { return m_nullValueHandling; } set { m_nullValueHandling = value; } }
+        public DefaultValueHandling DefaultValueHandling { get { return m_defaultValueHandling; } set { m_defaultValueHandling = value; } }
+        public PreserveReferencesHandling PreserveReferencesHandling { get { return m_preserveReferencesHandling; } set { m_preserveReferencesHandling = value; } }
+        public TypeNameHandling TypeNameHandling { get { return m_typeNameHandling; } set { m_typeNameHandling = value; } }
+        public MetadataPropertyHandling MetadataPropertyHandling { get { return m_metadataPropertyHandling; } set { m_metadataPropertyHandling = value; } }
+        public TypeNameAssemblyFormatHandling TypeNameAssemblyFormatHandling { get { return m_typeNameAssemblyFormatHandling; } set { m_typeNameAssemblyFormatHandling = value; } }
+        public ConstructorHandling ConstructorHandling { get { return m_constructorHandling; } set { m_constructorHandling = value; } }
+        public Formatting Formatting { get { return m_formatting; } set { m_formatting = value; } }
+        public DateFormatHandling DateFormatHandling { get { return m_dateFormatHandling; } set { m_dateFormatHandling = value; } }
+        public DateTimeZoneHandling DateTimeZoneHandling { get { return m_dateTimeZoneHandling; } set { m_dateTimeZoneHandling = value; } }
+        public DateParseHandling DateParseHandling { get { return m_dateParseHandling; } set { m_dateParseHandling = value; } }
+        public FloatFormatHandling FloatFormatHandling { get { return m_floatFormatHandling; } set { m_floatFormatHandling = value; } }
+        public FloatParseHandling FloatParseHandling { get { return m_floatParseHandling; } set { m_floatParseHandling = value; } }
+        public StringEscapeHandling StringEscapeHandling { get { return m_stringEscapeHandling; } set { m_stringEscapeHandling = value; } }
+        public string DateFormatString { get { return m_dateFormatString; } set { m_dateFormatString = value; } }
+        public int MaxDepth { get { return m_maxDepth; } set { m_maxDepth = value; } }
+        public bool CheckAdditionalContent { get { return m_checkAdditionalContent; } set { m_checkAdditionalContent = value; } }
+    }
+}

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetSettings.cs.meta
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0965887c6cc4c568643c6a3898d0c45
+timeCreated: 1627134558

--- a/Packages/UGF.Serialize.JsonNet/package.json
+++ b/Packages/UGF.Serialize.JsonNet/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.serialize.jsonnet",
   "displayName": "UGF.Serialize.JsonNet",
   "version": "1.0.1",
-  "unity": "2020.2",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Serializers implementation using Json.Net serialization.",
   "author": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.9f1
-m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)
+m_EditorVersion: 2020.3.14f1
+m_EditorVersionWithRevision: 2020.3.14f1 (d0d1bb862f9d)


### PR DESCRIPTION
- Change package _Unity_ version to `2020.3`.
- Add `SerializerJsonNetSettings` class with serializable _JsonNet Serializer Settings_ properties.
- Add `SerializerJsonNetAsset.OnCreateSettings()` method to override _JsonNet Serializer Settings_ creation.