### PR TITLE
Add generate type ids for type name converter

### DIFF
--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Type Collection Asset.asset
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Type Collection Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1693bcdba4504694a64e705491781065, type: 3}
+  m_Name: New Serializer Json Net Convert Type Collection Asset
+  m_EditorClassIdentifier: 
+  m_types: []

--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Type Collection Asset.asset
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Type Collection Asset.asset
@@ -12,4 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1693bcdba4504694a64e705491781065, type: 3}
   m_Name: New Serializer Json Net Convert Type Collection Asset
   m_EditorClassIdentifier: 
-  m_types: []
+  m_types:
+  - m_id: c5da71c28ebb4e31a0e5ec732d514f5d
+    m_type:
+      m_value: UGF.Serialize.Runtime.Bytes.SerializerTextToBytes, UGF.Serialize.Runtime,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Type Collection Asset.asset.meta
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Type Collection Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ded0707adbef8ba40b25d87c14834996
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Types Asset.asset
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/New Serializer Json Net Convert Types Asset.asset
@@ -14,6 +14,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_readable: 0
   m_indent: 2
+  m_settings:
+    m_referenceLoopHandling: 1
+    m_missingMemberHandling: 0
+    m_objectCreationHandling: 0
+    m_nullValueHandling: 1
+    m_defaultValueHandling: 0
+    m_preserveReferencesHandling: 0
+    m_typeNameHandling: 4
+    m_metadataPropertyHandling: 0
+    m_typeNameAssemblyFormatHandling: 0
+    m_constructorHandling: 0
+    m_formatting: 0
+    m_dateFormatHandling: 0
+    m_dateTimeZoneHandling: 3
+    m_dateParseHandling: 1
+    m_floatFormatHandling: 0
+    m_floatParseHandling: 0
+    m_stringEscapeHandling: 0
+    m_dateFormatString: yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK
+    m_maxDepth: 0
+    m_checkAdditionalContent: 0
   m_serializeNames: []
   m_deserializeNames: []
   m_types: []

--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/Resources/SerializerJsonNetCustom.asset
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/Resources/SerializerJsonNetCustom.asset
@@ -14,12 +14,34 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_readable: 1
   m_indent: 2
+  m_settings:
+    m_referenceLoopHandling: 1
+    m_missingMemberHandling: 0
+    m_objectCreationHandling: 0
+    m_nullValueHandling: 1
+    m_defaultValueHandling: 0
+    m_preserveReferencesHandling: 0
+    m_typeNameHandling: 4
+    m_metadataPropertyHandling: 0
+    m_typeNameAssemblyFormatHandling: 0
+    m_constructorHandling: 0
+    m_formatting: 0
+    m_dateFormatHandling: 0
+    m_dateTimeZoneHandling: 3
+    m_dateParseHandling: 1
+    m_floatFormatHandling: 0
+    m_floatParseHandling: 0
+    m_stringEscapeHandling: 0
+    m_dateFormatString: yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK
+    m_maxDepth: 0
+    m_checkAdditionalContent: 0
   m_serializeNames:
   - m_from: $type
     m_to: type
   m_deserializeNames:
   - m_from: type
     m_to: $type
+  m_allowAllTypes: 1
   m_types:
   - m_name: target1
     m_assembly: 

--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/Resources/SerializerJsonNetCustom.asset
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/Resources/SerializerJsonNetCustom.asset
@@ -53,3 +53,4 @@ MonoBehaviour:
     m_type:
       m_value: UGF.Serialize.JsonNet.Runtime.Tests.TestCustomSerializer+Target2,
         UGF.Serialize.JsonNet.Runtime.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_typeProviders: []

--- a/Assets/UGF.Serialize.JsonNet.Runtime.Tests/Resources/SerializerJsonNetCustomResult.json
+++ b/Assets/UGF.Serialize.JsonNet.Runtime.Tests/Resources/SerializerJsonNetCustomResult.json
@@ -1,4 +1,5 @@
 ﻿{
+  "type": "UGF.Serialize.JsonNet.Runtime.Tests.TestCustomSerializer+Target, UGF.Serialize.JsonNet.Runtime.Tests",
   "targets": [
     {
       "type": "target1",

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertNamesAssetEditor.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertNamesAssetEditor.cs
@@ -8,7 +8,6 @@ namespace UGF.Serialize.JsonNet.Editor
     [CustomEditor(typeof(SerializerJsonNetConvertNamesAsset), true)]
     internal class SerializerJsonNetConvertNamesAssetEditor : UnityEditor.Editor
     {
-        private SerializedProperty m_propertyScript;
         private SerializedProperty m_propertyReadable;
         private SerializedProperty m_propertyIndent;
         private SerializedProperty m_propertySettings;
@@ -17,7 +16,6 @@ namespace UGF.Serialize.JsonNet.Editor
 
         protected virtual void OnEnable()
         {
-            m_propertyScript = serializedObject.FindProperty("m_Script");
             m_propertyReadable = serializedObject.FindProperty("m_readable");
             m_propertyIndent = serializedObject.FindProperty("m_indent");
             m_propertySettings = serializedObject.FindProperty("m_settings");
@@ -44,11 +42,7 @@ namespace UGF.Serialize.JsonNet.Editor
 
         protected virtual void OnDrawGUILayout()
         {
-            using (new EditorGUI.DisabledScope(true))
-            {
-                EditorGUILayout.PropertyField(m_propertyScript);
-            }
-
+            EditorIMGUIUtility.DrawScriptProperty(serializedObject);
             EditorGUILayout.PropertyField(m_propertyReadable);
             EditorGUILayout.PropertyField(m_propertyIndent);
             EditorGUILayout.PropertyField(m_propertySettings);

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionAssetEditor.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionAssetEditor.cs
@@ -1,0 +1,34 @@
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UGF.Serialize.JsonNet.Runtime;
+using UnityEditor;
+
+namespace UGF.Serialize.JsonNet.Editor
+{
+    [CustomEditor(typeof(SerializerJsonNetConvertTypeCollectionAsset), true)]
+    internal class SerializerJsonNetConvertTypeCollectionAssetEditor : UnityEditor.Editor
+    {
+        private SerializerJsonNetConvertTypeCollectionListDrawer m_listTypes;
+
+        private void OnEnable()
+        {
+            m_listTypes = new SerializerJsonNetConvertTypeCollectionListDrawer(serializedObject.FindProperty("m_types"));
+            m_listTypes.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_listTypes.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                EditorIMGUIUtility.DrawScriptProperty(serializedObject);
+
+                m_listTypes.DrawGUILayout();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionAssetEditor.cs.meta
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionAssetEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a32d5447c0d1454f9c57392024c02df6
+timeCreated: 1639662776

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionDrawer.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionDrawer.cs
@@ -1,0 +1,31 @@
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Serialize.JsonNet.Editor
+{
+    internal class SerializerJsonNetConvertTypeCollectionListDrawer : ReorderableListDrawer
+    {
+        public SerializerJsonNetConvertTypeCollectionListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            SerializedProperty propertyId = serializedProperty.FindPropertyRelative("m_id");
+            SerializedProperty propertyType = serializedProperty.FindPropertyRelative("m_type.m_value");
+
+            EditorGUI.LabelField(position, $"{propertyId.stringValue}:{propertyType.stringValue}");
+        }
+
+        protected override float OnElementHeightContent(SerializedProperty serializedProperty, int index)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        protected override bool OnElementHasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            return false;
+        }
+    }
+}

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionDrawer.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using UGF.EditorTools.Editor.IMGUI;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UnityEditor;
 using UnityEngine;
 
@@ -13,9 +14,23 @@ namespace UGF.Serialize.JsonNet.Editor
         protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
         {
             SerializedProperty propertyId = serializedProperty.FindPropertyRelative("m_id");
-            SerializedProperty propertyType = serializedProperty.FindPropertyRelative("m_type.m_value");
+            SerializedProperty propertyType = serializedProperty.FindPropertyRelative("m_type");
 
-            EditorGUI.LabelField(position, $"{propertyId.stringValue}:{propertyType.stringValue}");
+            float space = EditorGUIUtility.standardVerticalSpacing * 2F;
+            float labelWidth = EditorGUIUtility.labelWidth + EditorIMGUIUtility.IndentPerLevel;
+
+            var rectId = new Rect(position.x, position.y, labelWidth, position.height);
+            var rectType = new Rect(rectId.xMax + space, position.y, position.width - rectId.width - space, position.height);
+
+            using (new LabelWidthScope(15F))
+            {
+                EditorGUI.PropertyField(rectId, propertyId);
+            }
+
+            using (new LabelWidthScope(35F))
+            {
+                EditorGUI.PropertyField(rectType, propertyType);
+            }
         }
 
         protected override float OnElementHeightContent(SerializedProperty serializedProperty, int index)

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionDrawer.cs.meta
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypeCollectionDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2a70a45aadce4529ae0b9bdd4d7eadcc
+timeCreated: 1639662825

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypesAssetEditor.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypesAssetEditor.cs
@@ -9,6 +9,7 @@ namespace UGF.Serialize.JsonNet.Editor
     {
         private SerializedProperty m_propertyAllowAllTypes;
         private ReorderableListDrawer m_listTypes;
+        private ReorderableListDrawer m_listTypeProviders;
 
         protected override void OnEnable()
         {
@@ -17,6 +18,8 @@ namespace UGF.Serialize.JsonNet.Editor
             m_propertyAllowAllTypes = serializedObject.FindProperty("m_allowAllTypes");
             m_listTypes = new ReorderableListDrawer(serializedObject.FindProperty("m_types"));
             m_listTypes.Enable();
+            m_listTypeProviders = new ReorderableListDrawer(serializedObject.FindProperty("m_typeProviders"));
+            m_listTypeProviders.Enable();
         }
 
         protected override void OnDisable()
@@ -24,6 +27,7 @@ namespace UGF.Serialize.JsonNet.Editor
             base.OnDisable();
 
             m_listTypes.Disable();
+            m_listTypeProviders.Disable();
         }
 
         protected override void OnDrawGUILayout()
@@ -33,6 +37,7 @@ namespace UGF.Serialize.JsonNet.Editor
             EditorGUILayout.PropertyField(m_propertyAllowAllTypes);
 
             m_listTypes.DrawGUILayout();
+            m_listTypeProviders.DrawGUILayout();
         }
     }
 }

--- a/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypesAssetEditor.cs
+++ b/Packages/UGF.Serialize.JsonNet/Editor/SerializerJsonNetConvertTypesAssetEditor.cs
@@ -7,14 +7,15 @@ namespace UGF.Serialize.JsonNet.Editor
     [CustomEditor(typeof(SerializerJsonNetConvertTypesAsset), true)]
     internal class SerializerJsonNetConvertTypesAssetEditor : SerializerJsonNetConvertNamesAssetEditor
     {
+        private SerializedProperty m_propertyAllowAllTypes;
         private ReorderableListDrawer m_listTypes;
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
+            m_propertyAllowAllTypes = serializedObject.FindProperty("m_allowAllTypes");
             m_listTypes = new ReorderableListDrawer(serializedObject.FindProperty("m_types"));
-
             m_listTypes.Enable();
         }
 
@@ -28,6 +29,8 @@ namespace UGF.Serialize.JsonNet.Editor
         protected override void OnDrawGUILayout()
         {
             base.OnDrawGUILayout();
+
+            EditorGUILayout.PropertyField(m_propertyAllowAllTypes);
 
             m_listTypes.DrawGUILayout();
         }

--- a/Packages/UGF.Serialize.JsonNet/Runtime/Binders.meta
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/Binders.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 981dfd892c1245049669d30d1d2d58e7
+timeCreated: 1639597769

--- a/Packages/UGF.Serialize.JsonNet/Runtime/Binders/SerializeJsonNetDisabledBinder.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/Binders/SerializeJsonNetDisabledBinder.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Newtonsoft.Json.Serialization;
+
+namespace UGF.Serialize.JsonNet.Runtime.Binders
+{
+    public class SerializeJsonNetDisabledBinder : ISerializationBinder
+    {
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            throw new ArgumentException($"Type not found by the specified name: '{typeName}'.");
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            throw new ArgumentException($"Type name not found by the specified type: '{serializedType}'.");
+        }
+    }
+}

--- a/Packages/UGF.Serialize.JsonNet/Runtime/Binders/SerializeJsonNetDisabledBinder.cs.meta
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/Binders/SerializeJsonNetDisabledBinder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7d3cc9e734fc49c9aa011be12a8d1a10
+timeCreated: 1639597772

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertNames.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertNames.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using UGF.JsonNet.Runtime;
 using UGF.JsonNet.Runtime.Converters;
 
 namespace UGF.Serialize.JsonNet.Runtime
@@ -27,18 +26,6 @@ namespace UGF.Serialize.JsonNet.Runtime
         protected override JsonReader OnCreateReader(Type targetType, string data)
         {
             return new ConvertPropertyNameReader(DeserializeNames, data);
-        }
-
-        protected override string OnSerialize(object target)
-        {
-            string result = base.OnSerialize(target);
-
-            if (Readable)
-            {
-                result = JsonNetUtility.Format(result, true, Indent);
-            }
-
-            return result;
         }
     }
 }

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeCollectionAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeCollectionAsset.cs
@@ -17,6 +17,7 @@ namespace UGF.Serialize.JsonNet.Runtime
         public struct TypeData
         {
             [SerializeField] private string m_id;
+            [TypeReferenceDropdown]
             [SerializeField] private TypeReference<object> m_type;
 
             public string Id { get { return m_id; } set { m_id = value; } }

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeCollectionAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeCollectionAsset.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Runtime.IMGUI.Types;
+using UGF.JsonNet.Runtime.Converters;
+using UnityEngine;
+
+namespace UGF.Serialize.JsonNet.Runtime
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer JsonNet Convert Type Collection", order = 2000)]
+    public class SerializerJsonNetConvertTypeCollectionAsset : SerializerJsonNetConvertTypeProviderAsset
+    {
+        [SerializeField] private List<TypeData> m_types = new List<TypeData>();
+
+        public List<TypeData> Types { get { return m_types; } }
+
+        [Serializable]
+        public struct TypeData
+        {
+            [SerializeField] private string m_id;
+            [SerializeField] private TypeReference<object> m_type;
+
+            public string Id { get { return m_id; } set { m_id = value; } }
+            public TypeReference<object> Type { get { return m_type; } set { m_type = value; } }
+        }
+
+        protected override void OnSetupTypes(IConvertTypeProvider provider)
+        {
+            for (int i = 0; i < m_types.Count; i++)
+            {
+                TypeData data = m_types[i];
+                Type type = data.Type.Get();
+
+                provider.Add(type, data.Id);
+            }
+        }
+    }
+}

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeCollectionAsset.cs.meta
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeCollectionAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1693bcdba4504694a64e705491781065
+timeCreated: 1639662532

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeProviderAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeProviderAsset.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using UGF.JsonNet.Runtime.Converters;
+using UnityEngine;
+
+namespace UGF.Serialize.JsonNet.Runtime
+{
+    public abstract class SerializerJsonNetConvertTypeProviderAsset : ScriptableObject
+    {
+        public void SetupTypes(IConvertTypeProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+
+            OnSetupTypes(provider);
+        }
+
+        protected abstract void OnSetupTypes(IConvertTypeProvider provider);
+    }
+}

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeProviderAsset.cs.meta
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypeProviderAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cc92fdc193e34193aae96fd91408c99d
+timeCreated: 1639598486

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
@@ -15,9 +15,11 @@ namespace UGF.Serialize.JsonNet.Runtime
     {
         [SerializeField] private bool m_allowAllTypes = true;
         [SerializeField] private List<ConvertTypeData> m_types = new List<ConvertTypeData>();
+        [SerializeField] private List<SerializerJsonNetConvertTypeProviderAsset> m_typeProviders = new List<SerializerJsonNetConvertTypeProviderAsset>();
 
         public bool AllowAllTypes { get { return m_allowAllTypes; } set { m_allowAllTypes = value; } }
         public List<ConvertTypeData> Types { get { return m_types; } }
+        public List<SerializerJsonNetConvertTypeProviderAsset> TypeProviders { get { return m_typeProviders; } }
 
         [Serializable]
         public struct ConvertTypeData

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
@@ -77,6 +77,13 @@ namespace UGF.Serialize.JsonNet.Runtime
                     provider.Add(type, data.Name);
                 }
             }
+
+            for (int i = 0; i < m_typeProviders.Count; i++)
+            {
+                SerializerJsonNetConvertTypeProviderAsset typeProvider = m_typeProviders[i];
+
+                typeProvider.SetupTypes(provider);
+            }
         }
     }
 }

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetConvertTypesAsset.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using UGF.EditorTools.Runtime.IMGUI.Types;
 using UGF.JsonNet.Runtime.Converters;
+using UGF.Serialize.JsonNet.Runtime.Binders;
 using UGF.Serialize.Runtime;
 using UnityEngine;
 
@@ -11,8 +13,10 @@ namespace UGF.Serialize.JsonNet.Runtime
     [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer JsonNet Convert Types", order = 2000)]
     public class SerializerJsonNetConvertTypesAsset : SerializerJsonNetConvertNamesAsset
     {
+        [SerializeField] private bool m_allowAllTypes = true;
         [SerializeField] private List<ConvertTypeData> m_types = new List<ConvertTypeData>();
 
+        public bool AllowAllTypes { get { return m_allowAllTypes; } set { m_allowAllTypes = value; } }
         public List<ConvertTypeData> Types { get { return m_types; } }
 
         [Serializable]
@@ -35,7 +39,7 @@ namespace UGF.Serialize.JsonNet.Runtime
 
         protected override ISerializer<string> OnBuildTyped()
         {
-            var binder = new ConvertTypeNameBinder();
+            var binder = new ConvertTypeNameBinder(new ConvertTypeProvider(), m_allowAllTypes ? new DefaultSerializationBinder() : new SerializeJsonNetDisabledBinder());
 
             SetupTypes(binder.Provider);
 

--- a/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetCustom.cs
+++ b/Packages/UGF.Serialize.JsonNet/Runtime/SerializerJsonNetCustom.cs
@@ -34,30 +34,26 @@ namespace UGF.Serialize.JsonNet.Runtime
         protected override string OnSerialize(object target)
         {
             JsonSerializer serializer = OnCreateSerializer();
+            using JsonWriter writer = OnCreateWriter(target);
 
-            using (JsonWriter writer = OnCreateWriter(target))
+            serializer.Serialize(writer, target, typeof(object));
+
+            string result = writer.ToString();
+
+            if (Readable)
             {
-                serializer.Serialize(writer, target);
-
-                string result = writer.ToString();
-
-                if (Readable)
-                {
-                    result = JsonNetUtility.Format(result, true, Indent);
-                }
-
-                return result;
+                result = JsonNetUtility.Format(result, true, Indent);
             }
+
+            return result;
         }
 
         protected override object OnDeserialize(Type targetType, string data)
         {
             JsonSerializer serializer = OnCreateSerializer();
+            using JsonReader reader = OnCreateReader(targetType, data);
 
-            using (JsonReader reader = OnCreateReader(targetType, data))
-            {
-                return serializer.Deserialize(reader, targetType);
-            }
+            return serializer.Deserialize(reader, targetType);
         }
     }
 }

--- a/Packages/UGF.Serialize.JsonNet/package.json
+++ b/Packages/UGF.Serialize.JsonNet/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.serialize.jsonnet",
   "displayName": "UGF.Serialize.JsonNet",
   "version": "2.0.0",
-  "unity": "2020.3",
+  "unity": "2021.2",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Serializers implementation using Json.Net serialization.",
   "author": {

--- a/Packages/UGF.Serialize.JsonNet/package.json
+++ b/Packages/UGF.Serialize.JsonNet/package.json
@@ -19,7 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.serialize": "5.0.0-preview",
-    "com.ugf.jsonnet": "1.3.0"
+    "com.ugf.serialize": "5.0.0",
+    "com.ugf.jsonnet": "1.4.0"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.27"
+    "com.unity.test-framework": "1.1.30"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -75,7 +75,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.27",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,37 +8,37 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.11.1",
+      "version": "2.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.jsonnet": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.0"
+        "com.unity.nuget.newtonsoft-json": "2.0.2"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.runtimetools": {
-      "version": "2.2.0",
+      "version": "2.4.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.serialize": {
-      "version": "5.0.0-preview",
+      "version": "5.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.ugf.builder": "2.0.1",
-        "com.ugf.editortools": "1.11.1",
-        "com.ugf.runtimetools": "2.2.0"
+        "com.ugf.editortools": "2.1.0",
+        "com.ugf.runtimetools": "2.4.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -47,8 +47,8 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.serialize": "5.0.0-preview",
-        "com.ugf.jsonnet": "1.3.0"
+        "com.ugf.serialize": "5.0.0",
+        "com.ugf.jsonnet": "1.4.0"
       }
     },
     "com.unity.ext.nunit": {
@@ -68,7 +68,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "depth": 2,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/MemorySettings.asset
+++ b/ProjectSettings/MemorySettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!387306366 &1
+MemorySettings:
+  m_ObjectHideFlags: 0
+  m_EditorMemorySettings:
+    m_MainAllocatorBlockSize: -1
+    m_ThreadAllocatorBlockSize: -1
+    m_MainGfxBlockSize: -1
+    m_ThreadGfxBlockSize: -1
+    m_CacheBlockSize: -1
+    m_TypetreeBlockSize: -1
+    m_ProfilerBlockSize: -1
+    m_ProfilerEditorBlockSize: -1
+    m_BucketAllocatorGranularity: -1
+    m_BucketAllocatorBucketsCount: -1
+    m_BucketAllocatorBlockSize: -1
+    m_BucketAllocatorBlockCount: -1
+    m_ProfilerBucketAllocatorGranularity: -1
+    m_ProfilerBucketAllocatorBucketsCount: -1
+    m_ProfilerBucketAllocatorBlockSize: -1
+    m_ProfilerBucketAllocatorBlockCount: -1
+    m_TempAllocatorSizeMain: -1
+    m_JobTempAllocatorBlockSize: -1
+    m_BackgroundJobTempAllocatorBlockSize: -1
+    m_JobTempAllocatorReducedBlockSize: -1
+    m_TempAllocatorSizeGIBakingWorker: -1
+    m_TempAllocatorSizeNavMeshWorker: -1
+    m_TempAllocatorSizeAudioWorker: -1
+    m_TempAllocatorSizeCloudWorker: -1
+    m_TempAllocatorSizeGfx: -1
+    m_TempAllocatorSizeJobWorker: -1
+    m_TempAllocatorSizeBackgroundWorker: -1
+    m_TempAllocatorSizePreloadManager: -1
+  m_PlatformMemorySettings: {}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 21
+  serializedVersion: 23
   productGUID: 7c19d94e2fdbc244e88c2c8640c81325
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -68,6 +68,12 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 0
   androidUseSwappy: 0
   androidBlitType: 0
+  androidResizableWindow: 0
+  androidDefaultWindowWidth: 1920
+  androidDefaultWindowHeight: 1080
+  androidMinimumWindowWidth: 400
+  androidMinimumWindowHeight: 300
+  androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -121,6 +127,7 @@ PlayerSettings:
   vulkanEnableSetSRGBWrite: 0
   vulkanEnablePreTransform: 0
   vulkanEnableLateAcquireNextImage: 0
+  vulkanEnableCommandBufferRecycling: 1
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -153,7 +160,7 @@ PlayerSettings:
     tvOS: 0
   overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 19
+  AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -209,11 +216,13 @@ PlayerSettings:
   iOSLaunchScreeniPadCustomStoryboardPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
+  macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
   metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
+  iosCopyPluginsCodeInsteadOfSymlink: 0
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
@@ -223,6 +232,7 @@ PlayerSettings:
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
+  shaderPrecisionModel: 0
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
   templatePackageId: com.unity.template.3d@1.0.11
   templateDefaultScene: Assets/Scenes/SampleScene.unity
@@ -234,6 +244,7 @@ PlayerSettings:
   useCustomGradlePropertiesTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 1
+  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: '{inproject}: '
@@ -250,13 +261,203 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  chromeosInputEmulation: 1
   AndroidMinifyWithR8: 0
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: iPhone
+    m_Icons:
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 87
+      m_Height: 87
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 60
+      m_Height: 60
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 20
+      m_Height: 20
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 1024
+      m_Height: 1024
+      m_Kind: 4
+      m_SubKind: App Store
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -308,7 +509,7 @@ PlayerSettings:
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
     m_APIs: 150000000b000000
-    m_Automatic: 0
+    m_Automatic: 1
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000
     m_Automatic: 1
@@ -335,6 +536,7 @@ PlayerSettings:
   m_BuildTargetGroupLightmapEncodingQuality: []
   m_BuildTargetGroupLightmapSettings: []
   m_BuildTargetNormalMapEncoding: []
+  m_BuildTargetDefaultTextureCompressionFormat: []
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
@@ -344,6 +546,7 @@ PlayerSettings:
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
+  bluetoothUsageDescription: 
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
@@ -352,6 +555,7 @@ PlayerSettings:
   switchScreenResolutionBehavior: 2
   switchUseCPUProfiler: 0
   switchUseGOLDLinker: 0
+  switchLTOSetting: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
   switchTitleNames_0: 
@@ -369,6 +573,7 @@ PlayerSettings:
   switchTitleNames_12: 
   switchTitleNames_13: 
   switchTitleNames_14: 
+  switchTitleNames_15: 
   switchPublisherNames_0: 
   switchPublisherNames_1: 
   switchPublisherNames_2: 
@@ -384,6 +589,7 @@ PlayerSettings:
   switchPublisherNames_12: 
   switchPublisherNames_13: 
   switchPublisherNames_14: 
+  switchPublisherNames_15: 
   switchIcons_0: {fileID: 0}
   switchIcons_1: {fileID: 0}
   switchIcons_2: {fileID: 0}
@@ -399,6 +605,7 @@ PlayerSettings:
   switchIcons_12: {fileID: 0}
   switchIcons_13: {fileID: 0}
   switchIcons_14: {fileID: 0}
+  switchIcons_15: {fileID: 0}
   switchSmallIcons_0: {fileID: 0}
   switchSmallIcons_1: {fileID: 0}
   switchSmallIcons_2: {fileID: 0}
@@ -414,6 +621,7 @@ PlayerSettings:
   switchSmallIcons_12: {fileID: 0}
   switchSmallIcons_13: {fileID: 0}
   switchSmallIcons_14: {fileID: 0}
+  switchSmallIcons_15: {fileID: 0}
   switchManualHTML: 
   switchAccessibleURLs: 
   switchLegalInformation: 
@@ -477,6 +685,10 @@ PlayerSettings:
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
   switchUseNewStyleFilepaths: 0
+  switchUseMicroSleepForYield: 1
+  switchEnableRamDiskSupport: 0
+  switchMicroSleepForYieldTime: 25
+  switchRamDiskSpaceSize: 12
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -572,20 +784,22 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
   scriptingDefineSymbols:
-    1: 
+    Standalone: 
+  additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:
     Standalone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
+  suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
-  useReferenceAssemblies: 1
   enableRoslynAnalyzers: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 0
+  assemblyVersionValidation: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
@@ -634,6 +848,7 @@ PlayerSettings:
   XboxOneCapability: []
   XboxOneGameRating: {}
   XboxOneIsContentPackage: 0
+  XboxOneEnhancedXboxCompatibilityMode: 0
   XboxOneEnableGPUVariability: 0
   XboxOneSockets: {}
   XboxOneSplashScreen: {fileID: 0}
@@ -665,4 +880,6 @@ PlayerSettings:
   organizationId: 
   cloudEnabled: 0
   legacyClampBlendShapeWeights: 1
+  playerDataPath: 
+  forceSRGBBlit: 1
   virtualTexturingSupportEnabled: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.14f1
-m_EditorVersionWithRevision: 2020.3.14f1 (d0d1bb862f9d)
+m_EditorVersion: 2021.2.4f1
+m_EditorVersionWithRevision: 2021.2.4f1 (99ba6aa4c552)


### PR DESCRIPTION
- Update package _Unity_ version to `2021.2`.
- Update dependencies: `com.ugf.serialize` to `5.0.0` and `com.ugf.jsonnet` to `1.4.0` version.
- Add `SerializerJsonNetConvertTypesAsset.AllowAllTypes` property to determine whether to allow types which have not been added to the list.
- Add `SerializerJsonNetConvertTypesAsset.TypeProviders` property as collection of `SerializerJsonNetConvertTypeProviderAsset` assets which will be added to type provider.
- Add `SerializerJsonNetConvertTypeProviderAsset` abstract class to implement custom type provider.
- Add `SerializerJsonNetConvertTypeCollectionAsset` class as implementation of `SerializerJsonNetConvertTypeProviderAsset` class with collection of types by id.